### PR TITLE
Improve completed activity card

### DIFF
--- a/frontend/src/pages/CreateYourEvent.css
+++ b/frontend/src/pages/CreateYourEvent.css
@@ -302,17 +302,13 @@
 }
 
 .completed-activity-card {
-  width: 220px;
-  min-height: 160px;
-  border: 2px solid #d1d5db;
-  border-radius: 1rem;
-  padding: 1rem;
-  background: #ffffff;
+  width: 200px;
+  padding: 0.75rem;
+  border: 1px solid #374151;
+  border-radius: 0.75rem;
+  background: #fff;
   display: flex;
   flex-direction: column;
-  position: relative;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .completed-activity-card:hover {
@@ -327,19 +323,21 @@
   margin-bottom: 0.5rem;
 }
 
+.completed-activity-header a {
+  text-decoration: underline;
+  font-size: 0.875rem;
+}
+
 .completed-activity-detail {
   font-size: 0.875rem;
-  color: #374151;
-  margin-bottom: 0.5rem;
-  line-height: 1.4;
-  font-weight: 400;
+  margin-bottom: 0.25rem;
 }
 
 .completed-activity-detail:last-child {
   margin-bottom: 0;
 }
 
-.completed-activity-card .MuiIconButton-root {
+.completed-activity-card .MuiIconButton-sizeSmall {
   padding: 0.25rem;
   color: #6b7280;
   font-size: 1rem;
@@ -348,7 +346,7 @@
   height: 28px;
 }
 
-.completed-activity-card .MuiIconButton-root:hover {
+.completed-activity-card .MuiIconButton-sizeSmall:hover {
   background-color: rgba(99, 102, 241, 0.1);
   color: #6366f1;
 }

--- a/frontend/src/pages/CreateYourEvent.jsx
+++ b/frontend/src/pages/CreateYourEvent.jsx
@@ -415,38 +415,26 @@ export default function CreateYourEvent() {
                     <CardContent className="activity-card-content" sx={{ position: 'relative', paddingBottom: '60px' }}>
                       {activity.isCompleted ? (
                         // Collapsed view for completed activities
-                        <Box>
-                          <Box className="activity-option-header">
-                            <Box>
-                              <Typography variant="subtitle1" className="activity-option-title">
-                                {activity.name || 'Unnamed Activity'}
-                              </Typography>
-                              <Typography variant="body2" color="text.secondary">
-                                {activity.timeCommitment && `Time: ${activity.timeCommitment}`}
-                                {activity.timeCommitment && (activity.cost || (activity.minCost && activity.maxCost)) && ' • '}
-                                {activity.costMode === 'fixed' && activity.cost && `Cost: ${activity.cost}`}
-                                {activity.costMode === 'range' && activity.minCost && activity.maxCost && `Cost: ${activity.minCost} - ${activity.maxCost}`}
-                              </Typography>
-                            </Box>
-                            <Box>
-                              <IconButton 
-                                onClick={() => updateActivity(activity.id, 'isCompleted', false)}
-                                size="small"
-                                sx={{ mr: 1 }}
-                              >
-                                <EventNote />
-                              </IconButton>
-                              <IconButton 
-                                color="error" 
-                                onClick={() => removeActivity(activity.id)}
-                                size="small"
-                                className="delete-activity-btn"
-                              >
-                                <DeleteOutline />
-                              </IconButton>
-                            </Box>
-                          </Box>
-                        </Box>
+                        <Card className="completed-activity-card">
+                          <div className="completed-activity-header">
+                            <a onClick={() => updateActivity(activity.id, 'isCompleted', false)}>Edit Event</a>
+                            <IconButton size="small" onClick={() => updateActivity(activity.id, 'isCompleted', false)}>
+                              <Edit fontSize="small" />
+                            </IconButton>
+                          </div>
+                          <Typography align="center" className="completed-activity-detail">
+                            {activity.name}
+                          </Typography>
+                          <Typography className="completed-activity-detail">
+                            Estimated Time: {activity.timeCommitment}
+                          </Typography>
+                          <Typography className="completed-activity-detail">
+                            Vote For Activity: {activity.isVotable ? 'Yes' : 'No'}
+                          </Typography>
+                          <Typography className="completed-activity-detail" sx={{ mt: 0.5 }}>
+                            Cost: ${activity.cost}
+                          </Typography>
+                        </Card>
                       ) : (
                         // Full form view for incomplete activities
                         <Box>


### PR DESCRIPTION
## Summary
- style finished activities with `.completed-activity-card`
- show compact card layout for completed activities with Edit link

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e3eb16cf48330b91e0911e02025c1