### PR TITLE
Implement basic mobile layout

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,10 +12,13 @@ import {
   Container,
   Paper,
   Fade,
-  Chip
+  Chip,
+  useMediaQuery,
+  useTheme
 } from '@mui/material';
 import CreateYourEvent from './pages/CreateYourEvent';
 import EventProgressTracker from './components/EventProgressTracker';
+import MobileProgressTracker from './components/MobileProgressTracker';
 import { ArrowBack } from '@mui/icons-material';
 
 
@@ -123,6 +126,7 @@ const theme = createTheme({
 
 export default function App() {
   const [page, setPage] = useState('landing');
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
 const BackButton = () => (
     <Button
@@ -621,13 +625,14 @@ const BackButton = () => (
 
         {page === 'create' && (
           <Box sx={{ display: 'flex', height: '100vh', backgroundColor: '#fafafb', pt: 8 }}>
-            <EventProgressTracker activities={[]} />
-            <Box sx={{ flexGrow: 1, pt: 2, overflow: 'auto', ml: '280px' }}>
+            {!isMobile && <EventProgressTracker activities={[]} />}
+            <Box sx={{ flexGrow: 1, pt: 2, overflow: 'auto', ml: isMobile ? 0 : '280px', pb: isMobile ? '60px' : 0 }}>
               <Container maxWidth="md" sx={{ py: 4 }}>
                 <BackButton />
                 <CreateYourEvent />
               </Container>
             </Box>
+            {isMobile && <MobileProgressTracker activities={[]} />}
           </Box>
         )}
 

--- a/frontend/src/components/EventProgressTracker.css
+++ b/frontend/src/components/EventProgressTracker.css
@@ -154,6 +154,12 @@
   }
 }
 
+@media (max-width: 600px) {
+  .progress-tracker {
+    display: none;
+  }
+}
+
 /* Animation for step completion */
 .step-icon.complete {
   animation: checkmark 0.3s ease-in-out;

--- a/frontend/src/components/MobileProgressTracker.css
+++ b/frontend/src/components/MobileProgressTracker.css
@@ -1,0 +1,27 @@
+.mobile-progress-tracker {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: white;
+  border-top: 1px solid #e5e7eb;
+  z-index: 1000;
+  padding: 4px 0;
+}
+
+.mobile-step-icon {
+  width: 24px !important;
+  height: 24px !important;
+}
+
+.mobile-step-icon.complete {
+  color: #10b981 !important;
+}
+
+.mobile-step-icon.active {
+  color: #6366f1 !important;
+}
+
+.mobile-step-icon.inactive {
+  color: #d1d5db !important;
+}

--- a/frontend/src/components/MobileProgressTracker.jsx
+++ b/frontend/src/components/MobileProgressTracker.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Box, Stepper, Step, StepLabel } from '@mui/material';
+import { CheckCircle, RadioButtonUnchecked } from '@mui/icons-material';
+import './MobileProgressTracker.css';
+
+const MobileProgressTracker = ({ activities = [] }) => {
+  const first = activities[0] || {};
+  const step1Complete =
+    first.name && first.description &&
+    ((first.dateMode === 'single' && first.date && first.time) ||
+      (first.dateMode === 'range' && first.startDate && first.endDate) ||
+      (first.dateMode === 'suggestions' && first.dateTimeSuggestions && first.dateTimeSuggestions.length));
+
+  const status = {
+    step1: { complete: !!step1Complete, active: !step1Complete },
+    step2: { complete: false, active: !!step1Complete },
+    step3: { complete: false, active: false },
+    step4: { complete: false, active: false },
+    step5: { complete: false, active: false },
+  };
+
+  const steps = [
+    { label: 'Create', ...status.step1 },
+    { label: 'Gather', ...status.step2 },
+    { label: 'Confirm', ...status.step3 },
+    { label: 'Participants', ...status.step4 },
+    { label: 'Finish', ...status.step5 },
+  ];
+
+  const StepIconComponent = ({ active, completed }) => {
+    if (completed) return <CheckCircle className="mobile-step-icon complete" />;
+    if (active) return <RadioButtonUnchecked className="mobile-step-icon active" />;
+    return <RadioButtonUnchecked className="mobile-step-icon inactive" />;
+  };
+
+  return (
+    <Box className="mobile-progress-tracker">
+      <Stepper alternativeLabel>
+        {steps.map((step, index) => (
+          <Step key={index} active={step.active} completed={step.complete}>
+            <StepLabel StepIconComponent={StepIconComponent}>{step.label}</StepLabel>
+          </Step>
+        ))}
+      </Stepper>
+    </Box>
+  );
+};
+
+export default MobileProgressTracker;


### PR DESCRIPTION
## Summary
- add mobile progress tracker component and styles
- hide desktop tracker on small screens
- switch tracker layout based on screen size

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in backend

------
https://chatgpt.com/codex/tasks/task_e_6852ec0c976c83309474f5b95a3c5b49