### PR TITLE
Implement UnsavedChangesGuard and integrate in event form

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "react-router-dom": "^6.22.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -131,11 +131,7 @@ export default function App() {
 const BackButton = () => (
     <Button
       variant="text"
-      onClick={() => {
-        if (window.confirm('Are you sure you want to leave?')) {
-          setPage('landing');
-        }
-      }}
+      onClick={() => setPage('landing')}
       sx={{
         mb: 3,
         color: '#6366f1',

--- a/frontend/src/components/UnsavedChangesGuard.tsx
+++ b/frontend/src/components/UnsavedChangesGuard.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+
+interface UnsavedChangesGuardProps {
+  isDirty: boolean;
+  children: (props: { attemptNavigate: (path: string) => void }) => React.ReactNode;
+}
+
+const UnsavedChangesGuard: React.FC<UnsavedChangesGuardProps> = ({ isDirty, children }) => {
+  const navigate = useNavigate();
+  const [pendingPath, setPendingPath] = useState<string | null>(null);
+
+  const handleClose = () => setPendingPath(null);
+
+  const attemptNavigate = (path: string) => {
+    if (!isDirty) {
+      navigate(path);
+      return;
+    }
+    setPendingPath(path);
+  };
+
+  const confirmLeave = () => {
+    if (pendingPath) {
+      navigate(pendingPath);
+    }
+  };
+
+  return (
+    <>
+      {children({ attemptNavigate })}
+      <Dialog open={Boolean(pendingPath)} onClose={handleClose}>
+        <DialogTitle>Unsaved Changes</DialogTitle>
+        <DialogContent>
+          <Typography>You have unsaved changes—are you sure you want to leave?</Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} color="primary" variant="outlined">
+            Stay
+          </Button>
+          <Button onClick={confirmLeave} color="primary" variant="contained">
+            Leave
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default UnsavedChangesGuard;

--- a/frontend/src/pages/CreateYourEvent.jsx
+++ b/frontend/src/pages/CreateYourEvent.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import {
   Container,
   Button,
@@ -13,28 +13,33 @@ import PreviewEvent from './PreviewEvent';
 import EventDetailsSection from '../components/EventDetailsSection';
 import ActivityOptionsSection from '../components/ActivityOptionsSection';
 import ActivitySupportSection from '../components/ActivitySupportSection';
+import UnsavedChangesGuard from '../components/UnsavedChangesGuard';
 import './CreateYourEvent.css';
 
-export default function CreateYourEvent() {
-  const [eventData, setEventData] = useState({
-    name: '',
-    description: '',
-    isPublic: true,
-    rsvpDeadline: '',
-    maxParticipants: '',
-    tags: [],
-    tagsString: ''
-  });
+const initialEventData = {
+  name: '',
+  description: '',
+  isPublic: true,
+  rsvpDeadline: '',
+  maxParticipants: '',
+  tags: [],
+  tagsString: ''
+};
 
-  const [dateTimeData, setDateTimeData] = useState({
-    dateMode: 'single',
-    date: '',
-    time: '',
-    startDate: '',
-    endDate: '',
-    allowParticipantSelection: false,
-    requiredDayCount: ''
-  });
+const initialDateTimeData = {
+  dateMode: 'single',
+  date: '',
+  time: '',
+  startDate: '',
+  endDate: '',
+  allowParticipantSelection: false,
+  requiredDayCount: ''
+};
+
+export default function CreateYourEvent() {
+  const [eventData, setEventData] = useState({ ...initialEventData });
+
+  const [dateTimeData, setDateTimeData] = useState({ ...initialDateTimeData });
 
   const [activities, setActivities] = useState([]);
   const [activitySupports, setActivitySupports] = useState([]);
@@ -65,6 +70,17 @@ export default function CreateYourEvent() {
       conflicts: []
     }
   };
+
+  const formIsDirty = useMemo(
+    () =>
+      JSON.stringify(eventData) !== JSON.stringify(initialEventData) ||
+      JSON.stringify(dateTimeData) !== JSON.stringify(initialDateTimeData) ||
+      activities.length > 0 ||
+      activitySupports.length > 0 ||
+      requiredActivityCount !== '' ||
+      requiredSupportCount !== '',
+    [eventData, dateTimeData, activities, activitySupports, requiredActivityCount, requiredSupportCount]
+  );
 
   const handleEventDataChange = (field, value) => {
     setEventData(prev => ({
@@ -205,7 +221,9 @@ export default function CreateYourEvent() {
 
 
   return (
-    <>
+    <UnsavedChangesGuard isDirty={formIsDirty}>
+      {({ attemptNavigate }) => (
+        <>
     <Container maxWidth="md" className="single-event-container">
       <div className="single-event-header">
         <Typography variant="h4" gutterBottom className="single-event-title">
@@ -271,6 +289,8 @@ export default function CreateYourEvent() {
         {notification.message}
       </Alert>
     </Snackbar>
-    </>
+        </>
+      )}
+    </UnsavedChangesGuard>
   );
 }


### PR DESCRIPTION
## Summary
- add a Material UI based `UnsavedChangesGuard` component
- compute dirty state in `CreateYourEvent` and wrap content in guard
- remove native confirm usage in `App` back button
- add React Router dependency

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f3acb01c833090f8609e0fcf4a75