### PR TITLE
Enable unsaved changes popup

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,7 +19,6 @@ import {
 import CreateYourEvent from './pages/CreateYourEvent';
 import EventProgressTracker from './components/EventProgressTracker';
 import MobileProgressTracker from './components/MobileProgressTracker';
-import { ArrowBack } from '@mui/icons-material';
 
 
 const theme = createTheme({
@@ -128,24 +127,6 @@ export default function App() {
   const [page, setPage] = useState('landing');
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
-const BackButton = () => (
-    <Button
-      variant="text"
-      onClick={() => setPage('landing')}
-      sx={{
-        mb: 3,
-        color: '#6366f1',
-        '&:hover': {
-          backgroundColor: 'rgba(99, 102, 241, 0.04)',
-        },
-        px: 1,
-        py: 4,
-      }}
-      startIcon={<ArrowBack />}
-    >
-      Back to previous page
-    </Button>
-  );
 
   return (
     <ThemeProvider theme={theme}>
@@ -624,8 +605,7 @@ const BackButton = () => (
             {!isMobile && <EventProgressTracker activities={[]} />}
             <Box sx={{ flexGrow: 1, pt: 2, overflow: 'auto', ml: isMobile ? 0 : '280px', pb: isMobile ? '60px' : 0 }}>
               <Container maxWidth="md" sx={{ py: 4 }}>
-                <BackButton />
-                <CreateYourEvent />
+                <CreateYourEvent onBack={() => setPage('landing')} />
               </Container>
             </Box>
             {isMobile && <MobileProgressTracker activities={[]} />}

--- a/frontend/src/components/UnsavedChangesGuard.tsx
+++ b/frontend/src/components/UnsavedChangesGuard.tsx
@@ -1,36 +1,47 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
 
 interface UnsavedChangesGuardProps {
   isDirty: boolean;
-  children: (props: { attemptNavigate: (path: string) => void }) => React.ReactNode;
+  children: (props: { attemptNavigate: (navigateFn: () => void) => void }) => React.ReactNode;
 }
 
 const UnsavedChangesGuard: React.FC<UnsavedChangesGuardProps> = ({ isDirty, children }) => {
-  const navigate = useNavigate();
-  const [pendingPath, setPendingPath] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<(() => void) | null>(null);
 
-  const handleClose = () => setPendingPath(null);
+  const handleClose = () => setPendingAction(null);
 
-  const attemptNavigate = (path: string) => {
+  const attemptNavigate = (action: () => void) => {
     if (!isDirty) {
-      navigate(path);
+      action();
       return;
     }
-    setPendingPath(path);
+    setPendingAction(() => action);
   };
 
   const confirmLeave = () => {
-    if (pendingPath) {
-      navigate(pendingPath);
+    if (pendingAction) {
+      pendingAction();
     }
   };
+
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (isDirty) {
+        e.preventDefault();
+        e.returnValue = '';
+      }
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [isDirty]);
 
   return (
     <>
       {children({ attemptNavigate })}
-      <Dialog open={Boolean(pendingPath)} onClose={handleClose}>
+      <Dialog open={Boolean(pendingAction)} onClose={handleClose} PaperProps={{ sx: { borderRadius: 3 } }}>
         <DialogTitle>Unsaved Changes</DialogTitle>
         <DialogContent>
           <Typography>You have unsaved changes—are you sure you want to leave?</Typography>

--- a/frontend/src/pages/CreateYourEvent.jsx
+++ b/frontend/src/pages/CreateYourEvent.jsx
@@ -14,6 +14,7 @@ import EventDetailsSection from '../components/EventDetailsSection';
 import ActivityOptionsSection from '../components/ActivityOptionsSection';
 import ActivitySupportSection from '../components/ActivitySupportSection';
 import UnsavedChangesGuard from '../components/UnsavedChangesGuard';
+import { ArrowBack } from '@mui/icons-material';
 import './CreateYourEvent.css';
 
 const initialEventData = {
@@ -36,7 +37,7 @@ const initialDateTimeData = {
   requiredDayCount: ''
 };
 
-export default function CreateYourEvent() {
+export default function CreateYourEvent({ onBack }) {
   const [eventData, setEventData] = useState({ ...initialEventData });
 
   const [dateTimeData, setDateTimeData] = useState({ ...initialDateTimeData });
@@ -225,6 +226,20 @@ export default function CreateYourEvent() {
       {({ attemptNavigate }) => (
         <>
     <Container maxWidth="md" className="single-event-container">
+      <Button
+        variant="text"
+        onClick={() => attemptNavigate(onBack)}
+        sx={{
+          mb: 3,
+          color: '#6366f1',
+          '&:hover': { backgroundColor: 'rgba(99, 102, 241, 0.04)' },
+          px: 1,
+          py: 4,
+        }}
+        startIcon={<ArrowBack />}
+      >
+        Back to previous page
+      </Button>
       <div className="single-event-header">
         <Typography variant="h4" gutterBottom className="single-event-title">
           Create Your Event


### PR DESCRIPTION
## Summary
- rework UnsavedChangesGuard so it works without React Router
- prompt before closing the tab if there are unsaved changes
- show Back button inside the page and hook it up to the guard
- pass callback from `App` to allow returning to landing page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852fa2fb6dc83308d3f10691f429e33