### PR TITLE
Move events to dashboard and add progress UI

### DIFF
--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -16,11 +16,13 @@ import {
   Edit,
   Delete,
   CalendarToday,
+  ContentCopy,
 } from '@mui/icons-material';
 import { motion } from 'framer-motion';
-import { useDeleteEvent } from '../hooks/useApi';
+import { useDeleteEvent, useCreateEvent } from '../hooks/useApi';
 import { useNotification } from '../components/ErrorHandling';
 import { calculateEventCost } from '../utils/costUtils';
+import MiniEventProgress from './MiniEventProgress';
 
 const EventCard = ({ event, onView, onEdit }) => {
   const { showNotification } = useNotification();
@@ -29,11 +31,21 @@ const EventCard = ({ event, onView, onEdit }) => {
       showNotification('Event deleted successfully', 'success');
     },
   });
+  const cloneEventMutation = useCreateEvent({
+    onSuccess: () => {
+      showNotification('Event cloned successfully', 'success');
+    },
+  });
 
   const handleDelete = () => {
     if (window.confirm('Are you sure you want to delete this event?')) {
       deleteEventMutation.mutate(event._id);
     }
+  };
+
+  const handleClone = () => {
+    const { _id, eventCode, adminCode, createdAt, updatedAt, __v, ...data } = event;
+    cloneEventMutation.mutate({ ...data, eventData: { ...event.eventData, name: `${event.eventData?.name || 'Event'} (Copy)` } });
   };
 
   const getEventStatus = () => {
@@ -183,6 +195,9 @@ const EventCard = ({ event, onView, onEdit }) => {
           <IconButton size="small" onClick={() => onEdit(event)} color="primary">
             <Edit fontSize="small" />
           </IconButton>
+          <IconButton size="small" onClick={handleClone} color="primary" disabled={cloneEventMutation.isLoading}>
+            <ContentCopy fontSize="small" />
+          </IconButton>
           <IconButton
             size="small"
             onClick={handleDelete}
@@ -193,6 +208,9 @@ const EventCard = ({ event, onView, onEdit }) => {
           </IconButton>
         </Box>
       </CardActions>
+      <Box sx={{ px: 2, pb: 2 }}>
+        <MiniEventProgress event={event} />
+      </Box>
     </Card>
   );
 };

--- a/frontend/src/components/GlobalHeader.jsx
+++ b/frontend/src/components/GlobalHeader.jsx
@@ -2,9 +2,17 @@
 import React from 'react';
 import { Box, Container, Typography, Button } from '@mui/material';
 import { Event } from '@mui/icons-material';
+import { useNavigate } from 'react-router-dom';
 import ThemeToggle from './ThemeToggle';
+import { useAuth } from '../context/AuthContext';
 
 export default function GlobalHeader({ onHome, onViewEvents, currentPage }) {
+  const navigate = useNavigate();
+  const { user, signOut } = useAuth();
+  const handleSignOut = async () => {
+    await signOut();
+    navigate('/');
+  };
   return (
     <Box
       sx={{
@@ -73,7 +81,7 @@ export default function GlobalHeader({ onHome, onViewEvents, currentPage }) {
             >
               Features
             </Button>
-            {onViewEvents && (
+            {user && onViewEvents && (
               <Button
                 variant={currentPage === 'events' ? 'contained' : 'outlined'}
                 startIcon={<Event />}
@@ -95,33 +103,57 @@ export default function GlobalHeader({ onHome, onViewEvents, currentPage }) {
               </Button>
             )}
             <ThemeToggle />
-            <Button
-              variant="outlined"
-              size="small"
-              sx={{
-                ml: 1,
-                borderColor: 'divider',
-                color: 'text.primary',
-                '&:hover': {
-                  borderColor: 'primary.main',
-                  backgroundColor: 'action.hover',
-                },
-              }}
-            >
-              Log In
-            </Button>
-            <Button
-              variant="contained"
-              size="small"
-              sx={{
-                background: 'linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%)',
-                '&:hover': {
-                  background: 'linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%)',
-                },
-              }}
-            >
-              Sign Up
-            </Button>
+            {!user && (
+              <>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={() => navigate('/login')}
+                  sx={{
+                    ml: 1,
+                    borderColor: 'divider',
+                    color: 'text.primary',
+                    '&:hover': {
+                      borderColor: 'primary.main',
+                      backgroundColor: 'action.hover',
+                    },
+                  }}
+                >
+                  Log In
+                </Button>
+                <Button
+                  variant="contained"
+                  size="small"
+                  onClick={() => navigate('/login')}
+                  sx={{
+                    background: 'linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%)',
+                    '&:hover': {
+                      background: 'linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%)',
+                    },
+                  }}
+                >
+                  Sign Up
+                </Button>
+              </>
+            )}
+            {user && (
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={handleSignOut}
+                sx={{
+                  ml: 1,
+                  borderColor: 'divider',
+                  color: 'text.primary',
+                  '&:hover': {
+                    borderColor: 'primary.main',
+                    backgroundColor: 'action.hover',
+                  },
+                }}
+              >
+                Sign Out
+              </Button>
+            )}
           </Box>
         </Box>
       </Container>

--- a/frontend/src/components/MiniEventProgress.jsx
+++ b/frontend/src/components/MiniEventProgress.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import { CheckCircle, RadioButtonUnchecked } from '@mui/icons-material';
+
+export default function MiniEventProgress({ event }) {
+  const steps = [
+    !!event.eventData?.name,
+    event.activities?.length > 0,
+    event.activitySupports?.length > 0,
+    false,
+    false,
+  ];
+  return (
+    <Box sx={{ display: 'flex', gap: 0.5, mt: 1 }}>
+      {steps.map((complete, idx) =>
+        complete ? (
+          <CheckCircle key={idx} fontSize="small" color="primary" />
+        ) : (
+          <RadioButtonUnchecked key={idx} fontSize="small" color="disabled" />
+        )
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/pages/CreateYourEvent.jsx
+++ b/frontend/src/pages/CreateYourEvent.jsx
@@ -23,6 +23,7 @@ import UnsavedChangesGuard from '../components/UnsavedChangesGuard';
 import PreviewEvent from './PreviewEvent';
 import ActivityOptionsSection from '../components/ActivityOptionsSection';
 import ActivitySupportSection from '../components/ActivitySupportSection';
+import EventProgressTracker from '../components/EventProgressTracker';
 
 import './CreateYourEvent.css';
 
@@ -448,6 +449,7 @@ export default function CreateYourEvent({ onBack, editEvent = null }) {
 
   return (
     <ErrorBoundary>
+      <EventProgressTracker activities={activities} />
       <UnsavedChangesGuard isDirty={formIsDirty}>
         {({ attemptNavigate }) => (
           <Container maxWidth="md" className="single-event-container">

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,26 +1,13 @@
-import { useEffect, useState } from 'react'
-import { supabase } from '../lib/supabaseClient'
 import { useAuth } from '../context/AuthContext'
+import EventsList from './EventsList'
 
 export default function Dashboard() {
   const { user } = useAuth()
-  const [events, setEvents] = useState([])
-
-  useEffect(() => {
-    supabase
-      .from('events')
-      .select('*')
-      .then(({ data }) => setEvents(data))
-  }, [])
 
   return (
-    <div>
-      <h1>Welcome, {user.email}</h1>
-      <ul>
-        {events.map(e => (
-          <li key={e.id}>{e.title}</li>
-        ))}
-      </ul>
+    <div style={{ paddingTop: '100px' }}>
+      <h1 style={{ textAlign: 'center', marginBottom: '1rem' }}>Welcome, {user.email}</h1>
+      <EventsList />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- show logout/login buttons depending on auth state
- hide My Events from guests
- add mini event progress display and clone button
- restore progress tracker in event creation
- show EventsList on the dashboard

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm test --silent` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685c6ec3b9c0833096fc9468b7430113